### PR TITLE
Require node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "bugs": {
     "url": "https://github.com/Fcmam5/jelbann-js/issues"
   },
+  "engines": {
+    "node": "16.x"
+  },
   "homepage": "https://github.com/Fcmam5/jelbann-js#readme",
   "devDependencies": {
     "@stryker-mutator/core": "^6.4.1",


### PR DESCRIPTION
Just in case developer isn't using `nvm`